### PR TITLE
Refactor controllers/services for RESTful API responses

### DIFF
--- a/TaskTracker.API/Controllers/TaskController.cs
+++ b/TaskTracker.API/Controllers/TaskController.cs
@@ -1,42 +1,42 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using TaskTracker.Application.Interfaces.Services;
+using TaskTracker.Domain.Models;
+using Task = TaskTracker.Domain.Models.Task;
 
-namespace TaskTracker.API.Controllers
-{
+namespace TaskTracker.API.Controllers {
     [ApiController]
     [Authorize]
     [Route("tasks")]
-    public class TaskController(ITaskService taskService) : ControllerBase
-    {
+    public class TaskController : ControllerBase {
+        private readonly ITaskService _taskService;
+
+        public TaskController(ITaskService taskService) {
+            _taskService = taskService;
+        }
+
         [HttpGet]
-        public async Task<IActionResult> GetTasks()
-        {
-            return Ok(await taskService.GetTasks());
+        public async Task<IActionResult> GetTasks(int taskGroupId) {
+            var tasks = await _taskService.GetTasksByTaskGroup(taskGroupId);
+            return Ok(tasks);
         }
 
         [HttpPost]
-        public async Task<IActionResult> PostTask(Domain.Models.Task[] tasks)
-        {
-            await taskService.CreateTasks(tasks);
-            return Ok();
+        public async Task<IActionResult> PostTasks(Task[] tasks) {
+            var createdTasks = await _taskService.CreateTasks(tasks);
+            return Ok(createdTasks);
         }
 
         [HttpPut]
-        public async Task<IActionResult> PutTasks(Domain.Models.Task[] tasks)
-        {
-            await taskService.PutTasks(tasks);
-
-            return Ok();
+        public async Task<IActionResult> PutTasks(Task[] tasks) {
+            var updatedTasks = await _taskService.PutTasks(tasks);
+            return Ok(updatedTasks);
         }
 
         [HttpDelete]
-        public async Task<IActionResult> DeleteTasks(Domain.Models.Task[] tasksToDelete)
-        {
-            await taskService.DeleteTasks(tasksToDelete);
-
-            return Ok();
+        public async Task<IActionResult> DeleteTasks(int[] taskIds) {
+            var deletedIds = await _taskService.DeleteTasks(taskIds);
+            return Ok(deletedIds);
         }
     }
 }

--- a/TaskTracker.API/Controllers/TaskGroupController.cs
+++ b/TaskTracker.API/Controllers/TaskGroupController.cs
@@ -1,43 +1,37 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
 using TaskTracker.Application.Interfaces.Services;
-using TaskTracker.Application.Services;
 using TaskTracker.Domain.Models;
 
-namespace TaskTracker.API.Controllers
-{
-    [ApiController]
-    [Route("taskgroup")]
-    public class TaskGroupController(ITaskGroupService taskGroupService) : ControllerBase
-    {
-        [HttpGet]
-        public async Task<IActionResult> GetTaskGroups()
-        {
-            return Ok(await taskGroupService.GetTaskGroups());
-        }
+[ApiController]
+[Route("taskgroup")]
+public class TaskGroupController : ControllerBase {
+    private readonly ITaskGroupService _taskGroupService;
 
-        [HttpPost]
-        public async Task<IActionResult> PostTaskGroups(TaskGroup[] taskGroups)
-        {
-            await taskGroupService.PostTaskGroups(taskGroups);
+    public TaskGroupController(ITaskGroupService taskGroupService) {
+        _taskGroupService = taskGroupService;
+    }
 
-            return Ok();
-        }
+    [HttpGet]
+    public async Task<IActionResult> GetTaskGroups() {
+        var result = await _taskGroupService.GetTaskGroups();
+        return Ok(result);
+    }
 
-        [HttpPut]
-        public async Task<IActionResult> PutTaskGroups(TaskGroup[] taskGroups)
-        {
-            await  taskGroupService.PutTaskGroups(taskGroups);
+    [HttpPost]
+    public async Task<IActionResult> PostTaskGroups(TaskGroup[] taskGroups) {
+        var created = await _taskGroupService.PostTaskGroups(taskGroups);
+        return Ok(created);
+    }
 
-            return Ok(taskGroups);
-        }
+    [HttpPut]
+    public async Task<IActionResult> PutTaskGroups(TaskGroup[] taskGroups) {
+        var updated = await _taskGroupService.PutTaskGroups(taskGroups);
+        return Ok(updated);
+    }
 
-        [HttpDelete]
-        public async Task<IActionResult> DeleteTaskGroups(TaskGroup[] taskGroups)
-        {
-            await taskGroupService.DeleteTaskGroups(taskGroups);
-
-            return Ok();
-        }
+    [HttpDelete]
+    public async Task<IActionResult> DeleteTaskGroups(int[] taskGroupIds) {
+        var deletedIds = await _taskGroupService.DeleteTaskGroups(taskGroupIds);
+        return Ok(deletedIds);
     }
 }

--- a/TaskTracker.Application/Interfaces/Repositories/ITaskGroupRepository.cs
+++ b/TaskTracker.Application/Interfaces/Repositories/ITaskGroupRepository.cs
@@ -7,10 +7,10 @@ public interface ITaskGroupRepository
 {
     public Task<IEnumerable<TaskGroup>> GetTaskGroups();
 
-    public Task PostTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<TaskGroup>> PostTaskGroups(TaskGroup[] taskGroups);
 
-    public Task PutTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<TaskGroup>> PutTaskGroups(TaskGroup[] taskGroups);
 
-    public Task DeleteTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<int>> DeleteTaskGroups(int[] taskGroupIds);
 
 }

--- a/TaskTracker.Application/Interfaces/Repositories/ITaskRepository.cs
+++ b/TaskTracker.Application/Interfaces/Repositories/ITaskRepository.cs
@@ -5,11 +5,11 @@ namespace TaskTracker.Application.Interfaces.Repositories;
 
 public interface ITaskRepository
 {
-    public Task<IEnumerable<ModelTask>> GetTasks();
+    public Task<IEnumerable<ModelTask>> GetTasksByTaskGroup(int taskGroupId);
 
-    public Task CreateTasks(ModelTask[] tasks);
+    public Task<IEnumerable<ModelTask>> CreateTasks(ModelTask[] tasks);
 
-    public Task PutTasks(ModelTask[] tasks);
+    public Task<IEnumerable<ModelTask>> PutTasks(ModelTask[] tasks);
 
-    public Task DeleteTasks(ModelTask[] tasksToDelete);
+    public Task<IEnumerable<int>> DeleteTasks(int[] tasksToDelete);
 }

--- a/TaskTracker.Application/Interfaces/Services/ITaskGroupService.cs
+++ b/TaskTracker.Application/Interfaces/Services/ITaskGroupService.cs
@@ -7,10 +7,10 @@ public interface ITaskGroupService
 {
     public Task<IEnumerable<TaskGroup>> GetTaskGroups();
 
-    public Task PostTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<TaskGroup>> PostTaskGroups(TaskGroup[] taskGroups);
 
-    public Task PutTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<TaskGroup>> PutTaskGroups(TaskGroup[] taskGroups);
 
-    public Task DeleteTaskGroups(TaskGroup[] taskGroups);
+    public Task<IEnumerable<int>> DeleteTaskGroups(int[] taskGroupIds);
 
 }

--- a/TaskTracker.Application/Interfaces/Services/ITaskService.cs
+++ b/TaskTracker.Application/Interfaces/Services/ITaskService.cs
@@ -2,11 +2,11 @@ namespace TaskTracker.Application.Interfaces.Services;
 using ModelTask = Domain.Models.Task; 
 public interface ITaskService
 {
-    public Task<IEnumerable<ModelTask>> GetTasks();
+    public Task<IEnumerable<ModelTask>> GetTasksByTaskGroup(int taskGroupId);
 
-    public Task CreateTasks(ModelTask[] tasks);
+    public Task<IEnumerable<ModelTask>> CreateTasks(ModelTask[] tasks);
 
-    public Task PutTasks(ModelTask[] tasks);
+    public Task<IEnumerable<ModelTask>> PutTasks(ModelTask[] tasks);
 
-    public Task DeleteTasks(ModelTask[] tasksToDelete);
+    public Task<IEnumerable<int>> DeleteTasks(int[] tasksToDelete);
 }

--- a/TaskTracker.Application/Services/TaskGroupService.cs
+++ b/TaskTracker.Application/Services/TaskGroupService.cs
@@ -12,18 +12,18 @@ public class TaskGroupService(ITaskGroupRepository repository) : ITaskGroupServi
         return await repository.GetTaskGroups();
     }
 
-    public async Task PostTaskGroups(TaskGroup[] taskGroups)
+    public async Task<IEnumerable<TaskGroup>> PostTaskGroups(TaskGroup[] taskGroups)
     { 
-        await repository.PostTaskGroups(taskGroups);
+        return await repository.PostTaskGroups(taskGroups);
     }
 
-    public async Task PutTaskGroups(TaskGroup[] taskGroups)
+    public async Task<IEnumerable<TaskGroup>> PutTaskGroups(TaskGroup[] taskGroups)
     {
-        await repository.PutTaskGroups(taskGroups);
+        return await repository.PutTaskGroups(taskGroups);
     }
 
-    public async Task DeleteTaskGroups(TaskGroup[] taskGroups)
+    public async Task<IEnumerable<int>> DeleteTaskGroups(int[] taskGroupIds)
     {
-        await repository.DeleteTaskGroups(taskGroups);
+        return await repository.DeleteTaskGroups(taskGroupIds);
     }
 }

--- a/TaskTracker.Application/Services/TaskService.cs
+++ b/TaskTracker.Application/Services/TaskService.cs
@@ -5,23 +5,23 @@ namespace TaskTracker.Application.Services;
 
 public class TaskService(ITaskRepository taskRepository) : ITaskService
 {
-    public async Task<IEnumerable<Domain.Models.Task>> GetTasks()
+    public async Task<IEnumerable<Domain.Models.Task>> GetTasksByTaskGroup(int taskGroupId)
     {
-        return await taskRepository.GetTasks();
+        return await taskRepository.GetTasksByTaskGroup(taskGroupId);
     }
 
-    public async Task CreateTasks(Domain.Models.Task[] tasks)
+    public async Task<IEnumerable<Domain.Models.Task>> CreateTasks(Domain.Models.Task[] tasks)
     {
-        await taskRepository.CreateTasks(tasks);
+        return await taskRepository.CreateTasks(tasks);
     }
 
-    public async Task PutTasks(Domain.Models.Task[] tasks)
+    public async Task<IEnumerable<Domain.Models.Task>> PutTasks(Domain.Models.Task[] tasks)
     {
-        await taskRepository.PutTasks(tasks);
+        return await taskRepository.PutTasks(tasks);
     }
 
-    public async Task DeleteTasks(Domain.Models.Task[] tasksToDelete)
+    public async Task<IEnumerable<int>> DeleteTasks(int[] tasksToDelete)
     {
-        await taskRepository.DeleteTasks(tasksToDelete);
+        return await taskRepository.DeleteTasks(tasksToDelete);
     }
 }

--- a/TaskTracker.Infrastructure/Persistence/Repositories/TaskGroupRepository.cs
+++ b/TaskTracker.Infrastructure/Persistence/Repositories/TaskGroupRepository.cs
@@ -12,29 +12,32 @@ public class TaskGroupRepository(WebAPIDbContext context) : ITaskGroupRepository
         return await context.TaskGroups.Include(tg => tg.Tasks).ToListAsync();
     }
 
-    public async Task PostTaskGroups(TaskGroup[] taskGroups)
-    {
-        await context.TaskGroups.AddRangeAsync(taskGroups);
-        await context.SaveChangesAsync();
-    }
-
-    public async Task PutTaskGroups(TaskGroup[] taskGroups)
-    {
-        await context.TaskGroups.AddRangeAsync(taskGroups);
-        foreach (var taskGroup in taskGroups)
-        {
-            context.Entry(taskGroup).State = EntityState.Modified;
+    public async Task<IEnumerable<TaskGroup>> PostTaskGroups(TaskGroup[] taskGroups) {
+        foreach (var tg in taskGroups) {
+            context.TaskGroups.Add(tg);
         }
         await context.SaveChangesAsync();
+
+        return taskGroups;
     }
 
-    public async Task DeleteTaskGroups(TaskGroup[] taskGroups)
-    {
-        await context.TaskGroups.AddRangeAsync(taskGroups);
-        foreach (var taskGroup in taskGroups)
-        {
-            context.Entry(taskGroup).State = EntityState.Deleted;
+    public async Task<IEnumerable<TaskGroup>> PutTaskGroups(TaskGroup[] taskGroups) {
+        foreach (var tg in taskGroups) {
+            context.TaskGroups.Update(tg);
         }
         await context.SaveChangesAsync();
+
+        return taskGroups;
+    }
+
+    public async Task<IEnumerable<int>> DeleteTaskGroups(int[] taskGroupIds) {
+        var toDelete = context.TaskGroups
+            .Where(tg => taskGroupIds.Contains(tg.TaskGroupId))
+            .ToArray();
+
+        context.TaskGroups.RemoveRange(toDelete);
+        await context.SaveChangesAsync();
+
+        return toDelete.Select(t => t.TaskGroupId).ToArray();
     }
 }

--- a/TaskTracker.Infrastructure/Persistence/Repositories/TaskRepository.cs
+++ b/TaskTracker.Infrastructure/Persistence/Repositories/TaskRepository.cs
@@ -4,34 +4,40 @@ namespace TaskTracker.Infrastructure.Persistence.Repositories;
 
 public class TaskRepository(WebAPIDbContext context) : ITaskRepository
 {
-    public async Task<IEnumerable<Domain.Models.Task>> GetTasks()
+    public async Task<IEnumerable<Domain.Models.Task>> GetTasksByTaskGroup(int taskGroupId)
     {
-        return await context.Tasks.ToListAsync();
+        return await context.Tasks
+            .Where(t => t.TaskGroupId == taskGroupId)
+            .ToArrayAsync();
     }
 
-    public async Task CreateTasks(Domain.Models.Task[] tasks)
-    {
-        await context.Tasks.AddRangeAsync(tasks);
-        await context.SaveChangesAsync();
-    }
-
-    public async Task PutTasks(Domain.Models.Task[] tasks)
-    {
-        context.Tasks.AttachRange(tasks);
-        foreach(var task in tasks)
-        {
-            context.Entry(task).State = EntityState.Modified;
+    public async Task<IEnumerable<Domain.Models.Task>> CreateTasks(Domain.Models.Task[] tasks) {
+        foreach (var t in tasks) {
+            context.Tasks.Add(t);
         }
         await context.SaveChangesAsync();
+
+        return tasks;
     }
 
-    public async Task DeleteTasks(Domain.Models.Task[] tasksToDelete)
-    {
-        context.Tasks.AddRange(tasksToDelete);
-        foreach (var taskToDelete in tasksToDelete)
-        {
-            context.Entry(taskToDelete).State = EntityState.Deleted;
+    public async Task<IEnumerable<Domain.Models.Task>> PutTasks(Domain.Models.Task[] tasks) {
+        foreach (var t in tasks) {
+            context.Tasks.Update(t);
         }
         await context.SaveChangesAsync();
+
+        return tasks;
     }
+
+    public async Task<IEnumerable<int>> DeleteTasks(int[] taskIds) {
+        var toDelete = context.Tasks
+            .Where(t => taskIds.Contains(t.TaskId))
+            .ToArray();
+
+        context.Tasks.RemoveRange(toDelete);
+        await context.SaveChangesAsync();
+
+        return toDelete.Select(t => t.TaskId).ToArray();
+    }
+
 }

--- a/TaskTracker.Infrastructure/Persistence/WebAPIDbContext.cs
+++ b/TaskTracker.Infrastructure/Persistence/WebAPIDbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using TaskTracker.Domain.Models;
 using Task = TaskTracker.Domain.Models.Task;
 
@@ -20,7 +20,7 @@ namespace TaskTracker.Infrastructure.Persistence
                 .HasOne(e => e.TaskGroup)
                 .WithMany(e => e.Tasks)
                 .HasForeignKey(e => e.TaskGroupId)
-                .IsRequired(false);
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<TaskDependency>()
                 .HasKey(td => new { td.TaskId, td.DependsOnTaskId });


### PR DESCRIPTION
Refactored Task and TaskGroup controllers, services, and repositories to return affected entities or IDs for create, update, and delete operations. Task retrieval now supports filtering by TaskGroup. Delete endpoints now accept arrays of IDs. Enabled cascade delete for TaskGroup/Task relationship in EF configuration. Improves API consistency and client feedback.